### PR TITLE
Add multi-team support to this lovely script.

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -2,3 +2,5 @@ hubot-team contributors:
 
 - Mihai Cîrlănaru (mihai)
 - Tyom Semonov (tyom)
+- Katie Delfin (katiedelfin)
+- Olivier Lacan (olivierlacan)

--- a/src/team.coffee
+++ b/src/team.coffee
@@ -8,13 +8,15 @@
 #   HUBOT_TEAM_ADMIN - A comma separate list of user names
 #
 # Commands:
-#   hubot team +1 - add me to the team
-#   hubot team -1 - remove me from the team
-#   hubot team add (me|<user>) - add me or <user> to team
-#   hubot team remove (me|<user>) - remove me or <user> from team
-#   hubot team count - list the current size of the team
-#   hubot team (list|show) - list the people in the team
-#   hubot team (new|empty|clear) - clear team list
+#   hubot create <team_name> team - add me to the team
+#   hubot list teams - list all existing teams
+#   hubot <team_name> team +1 - add me to the team
+#   hubot <team_name> team -1 - remove me from the team
+#   hubot <team_name> team add (me|<user>) - add me or <user> to team
+#   hubot <team_name> team remove (me|<user>) - remove me or <user> from team
+#   hubot <team_name> team count - list the current size of the team
+#   hubot <team_name> team (list|show) - list the people in the team
+#   hubot <team_name> team (new|empty|clear) - clear team list
 #
 # Author:
 #   mihai
@@ -23,7 +25,7 @@ config =
   admin_list: process.env.HUBOT_TEAM_ADMIN
 
 module.exports = (robot) ->
-  robot.brain.data.team ||= {}
+  robot.brain.data.teams ||= {}
 
   unless config.admin_list?
     robot.logger.warning 'The HUBOT_TEAM_ADMIN environment variable not set'
@@ -33,76 +35,122 @@ module.exports = (robot) ->
   else
     admins = []
 
-  teamSize = () ->
-    count = 0
-    for u, part of robot.brain.data.team
-      count += part
-    count
+  teamSize = (team_name, msg) ->
+    return false unless teamExists(team_name, msg)
+    robot.brain.data.teams[team_name].length
 
-  addUserToTeam = (user, msg) ->
-    if robot.brain.data.team[user]
-      msg.send "#{user} already in the team"
+  addUserToTeam = (user, team_name, msg) ->
+    return unless teamExists(team_name, msg)
+
+    if user in robot.brain.data.teams[team_name]
+      msg.send "#{user} already in the #{team_name}"
     else
-      count = teamSize()
+      count = teamSize(team_name, msg)
       if count > 0
         countMessage = ", " + count
         countMessage += " others are in" if count > 1
         countMessage += " other is in" if count == 1
 
-      robot.brain.data.team[user] = 1
+      robot.brain.data.teams[team_name].push(user)
 
       message = "#{user} added to the team"
       message += countMessage if countMessage
       msg.send message
 
-  removeUserFromTeam = (user, msg) ->
-    if not robot.brain.data.team[user]
+  addTeam = (team_name, msg) ->
+    if robot.brain.data.teams[team_name]
+      msg.send "#{team_name} already exists"
+    else
+      robot.brain.data['teams'][team_name] = []
+      msg.send "#{team_name} team created!"
+
+  listTeams = (msg) ->
+    team_count = Object.keys(robot.brain.data.teams).length
+
+    if team_count > 0
+      message = "Team (#{team_count} total):\n"
+      for team of robot.brain.data.teams
+        message += "#{team}\n"
+        for user in robot.brain.data.teams[team]
+          message += "- #{user}\n"
+      msg.send message
+
+    else
+      msg.send "Oh noes, we gots no teams!"
+
+  removeUserFromTeam = (user, team_name, msg) ->
+    return unless teamExists(team_name, msg)
+
+    if user not in robot.brain.data.teams[team_name]
       msg.send "#{user} already out of the team"
     else
-      robot.brain.data.team[user] = 0
-      count = teamSize()
+      user_index = robot.brain.data.teams[team_name].indexOf(user)
+      robot.brain.data.teams[team_name].splice(user_index)
+      count = teamSize(team_name, msg)
       countMessage = ", " + count + " remaining" if count > 0
-      message = "#{user} removed from the team"
+      message = "#{user} removed from #{team_name}"
       message += countMessage if countMessage
       msg.send message
 
-  robot.respond /team add (\S*) ?.*/i, (msg) ->
-    user = msg.match[1]
+  teamExists = (team_name, msg) ->
+    if robot.brain.data.teams[team_name]
+      true
+    else
+      msg.send "#{team_name} does not exist, buddy."
+      false
+
+  robot.respond /create (\S*) team ?.*/i, (msg) ->
+    team_name = msg.match[1]
+    addTeam(team_name, msg)
+
+  robot.respond /list teams ?.*/i, (msg) ->
+    listTeams(msg)
+
+  robot.respond /(\S*) team add (\S*) ?.*/i, (msg) ->
+    team_name = msg.match[1]
+    user = msg.match[2]
     if user.toLocaleLowerCase() == "me"
       user = msg.message.user.name
-    addUserToTeam(user, msg)
+    addUserToTeam(user, team_name, msg)
 
-  robot.respond /team \+1 ?.*/i, (msg) ->
-    addUserToTeam(msg.message.user.name, msg)
+  robot.respond /(\S*) team \+1 ?.*/i, (msg) ->
+    team_name = msg.match[1]
+    addUserToTeam(msg.message.user.name, team_name, msg)
 
-  robot.respond /team remove (\S*) ?.*/i, (msg) ->
-    user = msg.match[1]
+  robot.respond /(\S*) team remove (\S*) ?.*/i, (msg) ->
+    team_name = msg.match[1]
+    user = msg.match[2]
     if user.toLocaleLowerCase() == "me"
       user = msg.message.user.name
-    removeUserFromTeam(user, msg)
+    removeUserFromTeam(user, team_name, msg)
 
-  robot.respond /team -1/i, (msg) ->
-    removeUserFromTeam(msg.message.user.name, msg)
+  robot.respond /(\S*) team -1/i, (msg) ->
+    team_name = msg.match[1]
+    removeUserFromTeam(msg.message.user.name, team_name, msg)
 
-  robot.respond /team count$/i, (msg) ->
-    msg.send "#{teamSize()} people are currently in the team"
+  robot.respond /(\S*) team count$/i, (msg) ->
+    team_name = msg.match[1]
+    return unless teamExists(team_name)
+    msg.send "#{teamSize(team_name, msg)} people are currently in the team"
 
-  robot.respond /team (list|show)$/i, (msg) ->
-    count = teamSize()
+  robot.respond /(\S*) team (list|show)$/i, (msg) ->
+    team_name = msg.match[1]
+    return unless teamExists(team_name)
+    count = teamSize(team_name, msg)
     if count == 0
       msg.send "There is no one in the team currently"
     else
       position = 0
       message = "Team (#{count} total):\n"
-      for user of robot.brain.data.team
-        if robot.brain.data.team[user] != 0
-          position += 1
-          message += "#{position}. #{user}\n"
+      for user in robot.brain.data.teams[team_name]
+        position += 1
+        message += "#{position}. #{user}\n"
       msg.send message
 
-  robot.respond /team (new|clear|empty)$/i, (msg) ->
+  robot.respond /(\S*) team (new|clear|empty)$/i, (msg) ->
+    team_name = msg.match[1]
     if msg.message.user.name in admins
-      robot.brain.data.team = {}
+      robot.brain.data.teams[team_name] = []
       msg.send "Team list cleared"
     else
       msg.reply "Sorry, only admins can clear the team members list"


### PR DESCRIPTION
It's now possible to add multiple teams (there are none by default).

Instead of storing users as keys we're storing them as array items
instead because it didn't seem like there was any relevant information
stored in the user object (if a user isn't a team member anymore
what's the point of keeping their object around?).

We can now:
- list all teams
- create a team
- add a user to a team
- add oneself to a team
- remove a user from a team

> Isn't it grand? Isn't it great?
> Isn't it swell? Isn't it fun?
> Isn't it?

Signed-off-by: Katie Delfin katiedelfin@gmail.com
